### PR TITLE
Change API_URL usage from absolute URL to root path setting.

### DIFF
--- a/fe/src/App.vue
+++ b/fe/src/App.vue
@@ -189,7 +189,7 @@ export default {
   }),
   methods: {
     getFlagImgPath(code) {
-      return `${API_URL}/static/flags/flag-${code}-h.svg`;
+      return `${API_URL}static/flags/flag-${code}-h.svg`;
     },
     changeLangFrom(code) {
       this.$router.push({

--- a/fe/src/common/config.js
+++ b/fe/src/common/config.js
@@ -1,4 +1,4 @@
-export const API_URL = "http://localhost";
+export const API_URL = "/";
 export const DEFAULT_BATCHSIZE = 200;
 export const DEFAULT_VARIANTS_WINDOW_FROM = 20;
 export const DEFAULT_VARIANTS_WINDOW_TO = 20;

--- a/fe/src/views/Alignments.vue
+++ b/fe/src/views/Alignments.vue
@@ -1181,7 +1181,7 @@ export default {
       });
     },
     getImgUrl(batch_id) {
-      return `${API_URL}/static/img/${this.username}/${this.processingMeta.meta.align_guid}.best_${batch_id}.png?rnd=${this.cacheKey}`;
+      return `${API_URL}static/img/${this.username}/${this.processingMeta.meta.align_guid}.best_${batch_id}.png?rnd=${this.cacheKey}`;
     },
     prepareUsedToLines() {
       let foo = new Set();

--- a/fe/src/views/Documents.vue
+++ b/fe/src/views/Documents.vue
@@ -226,7 +226,7 @@ export default {
   },
   methods: {
     getImgUrl(batch_id) {
-      return `${API_URL}/static/img/${this.username}/${
+      return `${API_URL}static/img/${this.username}/${
         this.processingMeta.meta.align_guid
       }.best_${batch_id}.png?rnd=${Math.random()}`;
     },

--- a/fe/src/views/Items.vue
+++ b/fe/src/views/Items.vue
@@ -183,8 +183,8 @@
                 </v-card-title>
               </div>
               <v-divider></v-divider>
-              <!-- <v-img :src="`${API_URL}/static/img/${username}/${processingMeta.meta.align_guid}.best_${batch_id}.png`"
-                :lazy-src="`${API_URL}/static/proc_img_stub.jpg`">
+              <!-- <v-img :src="`${API_URL}static/img/${username}/${processingMeta.meta.align_guid}.best_${batch_id}.png`"
+                :lazy-src="`${API_URL}static/proc_img_stub.jpg`">
                 <template v-slot:placeholder>
                   <v-row class="fill-height ma-0" align="center" justify="center">
                     <v-progress-circular indeterminate color="green"></v-progress-circular>
@@ -619,7 +619,7 @@
     },
     methods: {
       getImgUrl(batch_id) {
-        return `${API_URL}/static/img/${this.username}/${this.processingMeta.meta.align_guid}.best_${batch_id}.png?rnd=${Math.random()}`;
+        return `${API_URL}static/img/${this.username}/${this.processingMeta.meta.align_guid}.best_${batch_id}.png?rnd=${Math.random()}`;
       },
       prepareUsedToLines() {
         let foo = new Set();


### PR DESCRIPTION
Позволяет запускать сервис без указания в API_URL конкретного имени хоста, порта и протокола (http, https).

TODO связанное с URL: 
 1. Возможность задать API_URL через переменные среды
  2. Использование префикса для URL
     например если указать API_URL = /studio/
     то доступ будет по такому URL: http(s)://example.com/studio/
     Изменить @app.route в be/main.py с использования абсолютного url на префикс

    